### PR TITLE
Sometimes the text is nil

### DIFF
--- a/app/services/rapidfire/question_group_results.rb
+++ b/app/services/rapidfire/question_group_results.rb
@@ -14,9 +14,11 @@ module Rapidfire
           case question
           when Rapidfire::Questions::Select, Rapidfire::Questions::Radio,
             Rapidfire::Questions::Checkbox
-            answers = question.answers.map(&:answer_text).map { |text| text.split(',') }.flatten
+            answers = question.answers.map(&:answer_text).map do |text|
+              text.split(',') if !text.nil?
+            end
+            answers = answers.flatten
             answers.inject(Hash.new(0)) { |total, e| total[e] += 1; total }
-
           when Rapidfire::Questions::Short, Rapidfire::Questions::Date,
             Rapidfire::Questions::Long, Rapidfire::Questions::Numeric
             question.answers.pluck(:answer_text)


### PR DESCRIPTION
Only split if text is not nil fixes the issue.

```
NoMethodError in Rapidfire::QuestionGroupsController#results 
undefined method `split' for nil:NilClass
```
