### PR TITLE
Inline main_app routes for layout

### DIFF
--- a/app/helpers/rapidfire/application_helper.rb
+++ b/app/helpers/rapidfire/application_helper.rb
@@ -10,5 +10,25 @@ module Rapidfire
       answers = answer.answer_text.to_s.split(answers_delimiter)
       answers.include?(option)
     end
+
+    def method_missing(method, *args, &block)
+      if main_app_url_helper?(method)
+        main_app.send(method, *args)
+      else
+        super
+      end
+    end
+
+    def respond_to?(method)
+      main_app_url_helper?(method) || super
+    end
+
+    private
+
+    def main_app_url_helper?(method)
+      Rapidfire.inline_main_app_named_routes &&
+        (method.to_s.end_with?('_path') or method.to_s.end_with?('_url')) &&
+        main_app.respond_to?(method)
+    end
   end
 end

--- a/lib/rapidfire.rb
+++ b/lib/rapidfire.rb
@@ -10,6 +10,9 @@ module Rapidfire
   mattr_accessor :answers_delimiter
   self.answers_delimiter = "\r\n"
 
+  mattr_accessor :inline_main_app_named_routes
+  self.inline_main_app_named_routes = false
+
   def self.config
     yield(self)
   end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
 
   mount Rapidfire::Engine => "/rapidfire"
+
+  get :foobar, to: 'application#index', as: :main_app_route
 end

--- a/spec/helpers/rapidfire/application_helper_spec.rb
+++ b/spec/helpers/rapidfire/application_helper_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Rapidfire::ApplicationHelper do
+  describe 'Main app inline routes' do
+    before { Rapidfire.config { |config| config.inline_main_app_named_routes = true } }
+    after { Rapidfire.config { |config| config.inline_main_app_named_routes = false } }
+
+    it { expect(helper).to respond_to(:main_app_route_path) }
+    it { expect(helper.main_app_route_path).to eq('/foobar') }
+  end
+end


### PR DESCRIPTION
I have big and complicated layout in my app, and I don't want to edit it with all this `main_app.whatever_path`. So I made a solution first seen at https://github.com/KatanaCode/blogit

Create a file `config/initializers/rapifire.rb` with following code (the feature is off by default):

```ruby
Rapidfire.config do |config|
  config.inline_main_app_named_routes = true
end
```

And voila.

The problem is similar to that issue: https://github.com/code-mancers/rapidfire/issues/16