### PR TITLE
Proper label and input ids for checkbox and radios with non-sanitized values

### DIFF
--- a/app/services/rapidfire/answer_group_builder.rb
+++ b/app/services/rapidfire/answer_group_builder.rb
@@ -19,10 +19,10 @@ module Rapidfire
           # in case of checkboxes, values are submitted as an array of
           # strings. we will store answers as one big string separated
           # by delimiter.
+          text = text.values if text.is_a?(Hash)
           answer.answer_text =
             if text.is_a?(Array)
-              stripped_answers = strip_checkbox_answers(text)
-              stripped_answers.join(Rapidfire.answers_delimiter)
+              strip_checkbox_answers(text).join(Rapidfire.answers_delimiter)
             else
               text
             end
@@ -50,8 +50,8 @@ module Rapidfire
       end
     end
 
-    def strip_checkbox_answers(text)
-      text.reject(&:blank?).reject { |t| t == "0" }
+    def strip_checkbox_answers(answers)
+      answers.reject(&:blank?).reject { |t| t == "0" }
     end
   end
 end

--- a/app/views/rapidfire/answers/_checkbox.html.erb
+++ b/app/views/rapidfire/answers/_checkbox.html.erb
@@ -2,9 +2,9 @@
 
 <%= f.label :answer_text, answer.question.question_text %>
 <%= f.fields_for :answer_text do |af| %>
-  <%- answer.question.options.each do |option| %>
-    <%= af.label option do %>
-      <%= af.check_box nil, { id: nil, checked: checkbox_checked?(answer, option) }, option %>
+  <%- answer.question.options.each_with_index do |option, index| %>
+    <%= af.label index do %>
+      <%= af.check_box index, { checked: checkbox_checked?(answer, option) }, option %>
       <%= option %>
     <% end %>
   <% end %>

--- a/app/views/rapidfire/answers/_radio.html.erb
+++ b/app/views/rapidfire/answers/_radio.html.erb
@@ -1,9 +1,9 @@
 <%= render partial: "rapidfire/answers/errors", locals: {answer: answer} %>
 
 <%= f.label :answer_text, answer.question.question_text %>
-<%- answer.question.options.each do |option| %>
-  <%= f.label "answer_text_#{option}", option do %>
-    <%= f.radio_button :answer_text, option %>
+<%- answer.question.options.each_with_index do |option, index| %>
+  <%= f.label "answer_text_#{index}" do %>
+    <%= f.radio_button :answer_text, option, id: "#{f.object_name.gsub(/\]\[|[^-a-zA-Z0-9:.]/, "_").sub(/_$/, "")}_answer_text_#{index}" %>
     <%= option %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Before now label ids and input ids for checkbox and radios inputs were messed of unsanitized option values and sanitized values, that was a nightmare if you had some punctuation or non-latin symbols in options.
This commit fixes it.
It looks a little tricky, but I don't see a more simple and cleaner way without including something like `simple_form`.
