### PR TITLE
Enable defaults and placeholders for text and textarea inputs

### DIFF
--- a/app/models/rapidfire/question.rb
+++ b/app/models/rapidfire/question.rb
@@ -9,7 +9,7 @@ module Rapidfire
     serialize :validation_rules
 
     if Rails::VERSION::MAJOR == 3
-      attr_accessible :question_group, :question_text, :validation_rules, :answer_options
+      attr_accessible :question_group, :question_text, :default_text, :placeholder, :validation_rules, :answer_options
     end
 
     def self.inherited(child)

--- a/app/services/rapidfire/question_form.rb
+++ b/app/services/rapidfire/question_form.rb
@@ -18,7 +18,9 @@ module Rapidfire
     end
 
     attr_accessor :question_group, :question,
-      :type, :question_text, :answer_options, :answer_presence,
+      :type, :question_text,
+      :default_text, :placeholder,
+      :answer_options, :answer_presence,
       :answer_minimum_length, :answer_maximum_length,
       :answer_greater_than_or_equal_to, :answer_less_than_or_equal_to
 
@@ -55,6 +57,8 @@ module Rapidfire
       {
         :question_group => question_group,
         :question_text  => question_text,
+        :default_text => default_text,
+        :placeholder => placeholder,
         :answer_options => answer_options,
         :validation_rules => {
           :presence => answer_presence,
@@ -70,6 +74,8 @@ module Rapidfire
       self.type = question.type
       self.question_group  = question.question_group
       self.question_text   = question.question_text
+      self.default_text    = question.default_text
+      self.placeholder     = question.placeholder
       self.answer_options  = question.answer_options
       self.answer_presence = question.rules[:presence]
       self.answer_minimum_length = question.rules[:minimum]

--- a/app/views/rapidfire/answers/_long.html.erb
+++ b/app/views/rapidfire/answers/_long.html.erb
@@ -1,4 +1,4 @@
 <%= render partial: "rapidfire/answers/errors", locals: {answer: answer} %>
 
 <%= f.label :answer_text, answer.question.question_text %>
-<%= f.text_area :answer_text, :rows => 5 %>
+<%= f.text_area :answer_text, value: answer.question.default_text, :rows => 5, placeholder: answer.question.placeholder %>

--- a/app/views/rapidfire/answers/_short.html.erb
+++ b/app/views/rapidfire/answers/_short.html.erb
@@ -1,4 +1,4 @@
 <%= render partial: "rapidfire/answers/errors", locals: {answer: answer} %>
 
 <%= f.label :answer_text, answer.question.question_text %>
-<%= f.text_field :answer_text %>
+<%= f.text_field :answer_text, value: answer.question.default_text, placeholder: answer.question.placeholder %>

--- a/app/views/rapidfire/questions/_form.html.erb
+++ b/app/views/rapidfire/questions/_form.html.erb
@@ -15,6 +15,12 @@
   <%= f.label :question_text %>
   <%= f.text_field :question_text %>
 
+  <%= f.label :placeholder %>
+  <%= f.text_field :placeholder %>
+
+  <%= f.label :default_text %>
+  <%= f.text_field :default_text %>
+
   <%= f.label :answer_options %>
   <%= f.text_area :answer_options, rows: 5 %>
 

--- a/db/migrate/20130502195310_create_rapidfire_questions.rb
+++ b/db/migrate/20130502195310_create_rapidfire_questions.rb
@@ -4,6 +4,8 @@ class CreateRapidfireQuestions < ActiveRecord::Migration
       t.references :question_group
       t.string  :type
       t.string  :question_text
+      t.string  :default_text
+      t.string  :placeholder
       t.integer :position
       t.text :answer_options
       t.text :validation_rules


### PR DESCRIPTION
Used your gem to my personal project, and I add some functionality that enables defaults and placeholders for text and textarea inputs.
I tested it within my project (Rails 4.2.0, Ruby 2.2.0) but I couldn't bundle install the forked project due to an error during the install of `capybara-webkit-1.5.0`.
