### PR TITLE
Adding a layout setter

### DIFF
--- a/app/controllers/rapidfire/application_controller.rb
+++ b/app/controllers/rapidfire/application_controller.rb
@@ -1,5 +1,9 @@
 module Rapidfire
   class ApplicationController < ::ApplicationController
+    if Rapidfire.layout
+      layout Rapidfire.layout
+    end
+
     helper_method :can_administer?
 
     def authenticate_administrator!

--- a/lib/rapidfire.rb
+++ b/lib/rapidfire.rb
@@ -10,6 +10,9 @@ module Rapidfire
   mattr_accessor :answers_delimiter
   self.answers_delimiter = "\r\n"
 
+  # configuration for setting the layout
+  mattr_accessor :layout
+  
   def self.config
     yield(self)
   end


### PR DESCRIPTION
I needed to use a different layout than the application controller's. Now at the parent application we can define which layout rapidfire should use with: Rapidfire.layout = 'some_layout'. If not defined it will use the inherited one just like before.
