### PR TITLE
Update Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.0.0
-  - 2.1.10
-  - 2.2.5
-  - 2.3.1
+  - 2.1.9
+  - 2.2.6
+  - 2.3.3
 
 gemfile:
   - gemfiles/Gemfile.rails-3.2.x
@@ -16,13 +15,11 @@ gemfile:
 matrix:
   exclude:
     # has test/unit/testcase removed, and also 3.2.x is too old to support
-    # ruby 2.2.2. so ignoring this combination.
-    - rvm: 2.2.5
+    # ruby 2.2.x. so ignoring this combination.
+    - rvm: 2.2.6
       gemfile: gemfiles/Gemfile.rails-3.2.x
     # rack with rails 5 cannot be installed in ruby versions prior to 2.2.2
-    - rvm: 2.0.0
-      gemfile: gemfiles/Gemfile.rails-5.0.x
-    - rvm: 2.1.10
+    - rvm: 2.1.9
       gemfile: gemfiles/Gemfile.rails-5.0.x
 
 before_script:


### PR DESCRIPTION
Changes:
 - Remove Ruby 2.0.0 since it is not supported anymore since 2016-02-24: [Support plans for Ruby 2.0.0 and Ruby 2.1](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/).
 - Downgrade Ruby 2.1.10 to 2.1.9. From  [Ruby 2.1.10 Released](https://www.ruby-lang.org/en/news/2016/04/01/ruby-2-1-10-released/):
> This release is not intended for production use, but for compatibility tests with two-digit version numbers. You don’t have to replace Ruby 2.1.9 by 2.1.10 in normal use.

 - Upgrade Ruby 2.2.5 to 2.2.6: [Ruby 2.2.6 Released](https://www.ruby-lang.org/en/news/2016/11/15/ruby-2-2-6-released/);
 - Upgrade Ruby 2.31. to 2.3.3: [Ruby 2.3.3 Released](https://www.ruby-lang.org/en/news/2016/11/21/ruby-2-3-3-released/)