### PR TITLE
Wrap each question in a <div> with a proper class name. 

### DIFF
--- a/app/helpers/rapidfire/application_helper.rb
+++ b/app/helpers/rapidfire/application_helper.rb
@@ -2,7 +2,7 @@ module Rapidfire
   module ApplicationHelper
     def render_answer_form_helper(answer, form)
       partial = answer.question.type.to_s.split("::").last.downcase
-      render partial: "rapidfire/answers/#{partial}", locals: { f: form, answer: answer }
+      render partial: "answer_wrapper", locals: { f: form, answer: answer, partial: partial }
     end
 
     def checkbox_checked?(answer, option)
@@ -10,5 +10,6 @@ module Rapidfire
       answers = answer.answer_text.to_s.split(answers_delimiter)
       answers.include?(option)
     end
+
   end
 end

--- a/app/views/rapidfire/attempts/_answer_wrapper.html.erb
+++ b/app/views/rapidfire/attempts/_answer_wrapper.html.erb
@@ -1,0 +1,3 @@
+<div class='<%= partial -%>_question' >
+  <%= render partial: "rapidfire/answers/#{partial}", locals: { f: f, answer: answer } -%>
+</div>


### PR DESCRIPTION
In attempts/new view:
Wrap each question (along with it's answers) in a special 'div' element.
The div's class name matches the question type ('checkbox_question', 'radio_question' etc...)
This can be beneficial for applying styles to questions.

No spec written, since it's a small view related change,  I can write one if needed.

