### PR TITLE
Include info on how to prevent routing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ You can see them by running `bundle exec rake routes`.
 
    You can distribute this url so that survey takers can answer a particular survey
    of your interest.
+3. If you have an established application that uses route helpers and/or the
+   `url_for([@model1, @model2])` style, you can include your route helpers in 
+   RapidFire by adding `config/initializers/rapidfire.rb` with the 
+   following content:
+   
+   ```
+   Rapidfire::ApplicationController.class_eval do
+     helper Rails.application.routes.url_helpers
+   end
+   ```
 
 ### Survey Results
 A new api is released which helps in seeing results for each survey. The api is:

--- a/README.md
+++ b/README.md
@@ -99,9 +99,20 @@ You can see them by running `bundle exec rake routes`.
    RapidFire by adding `config/initializers/rapidfire.rb` with the 
    following content:
    
-   ```
-   Rapidfire::ApplicationController.class_eval do
-     helper Rails.application.routes.url_helpers
+   ```ruby
+   Rails.application.config.after_initialize do
+     Rails.application.reload_routes!
+
+     Rapidfire::ApplicationController.class_eval do
+       main_app_methods = Rails.application.routes.url_helpers.methods
+       main_app_route_methods = main_app_methods.select{|m| m =~ /_url$/ || m =~ /_path$/ }
+       main_app_route_methods.each do |m|
+         define_method m do |*args|
+           main_app.public_send(m, *args)
+         end
+         helper_method m
+       end
+     end
    end
    ```
 


### PR DESCRIPTION
When an application is already well established, it may be too time-consuming to change all instances of route helpers from the resource-based style to actually name the method, and all where named methods are used, to be prefixed by main_app.