### PR TITLE
Fix to use specified logged in scope

### DIFF
--- a/app/controllers/rapidfire/application_controller.rb
+++ b/app/controllers/rapidfire/application_controller.rb
@@ -14,8 +14,12 @@ module Rapidfire
 
     # Override prefixes to consider the scoped.
     # for method current_user
-    def scoped
-      :user
+    def rapidfire_scoped
+      if !defined?(super)
+        :user
+      else
+        super
+      end
     end
   end
 end

--- a/app/controllers/rapidfire/attempts_controller.rb
+++ b/app/controllers/rapidfire/attempts_controller.rb
@@ -38,7 +38,7 @@ module Rapidfire
 
     def attempt_params
       answer_params = { params: (params[:attempt] || {}) }
-      answer_params.merge(user: current_user, survey: @survey, attempt_id: params[:id])
+      answer_params.merge(user: rapidfire_current_scoped, survey: @survey, attempt_id: params[:id])
     end
 
     # Override path to redirect after answer the survey
@@ -54,7 +54,7 @@ module Rapidfire
     end
 
     def rapidfire_current_scoped
-      send 'current_'+scoped.to_s
+      send 'current_' + rapidfire_scoped.to_s
     end
   end
 end


### PR DESCRIPTION
Rapidfire includes a method that looks to allow the programmer to specify `current_admin` or `current_student` or whatever scope of user they want, but it ends up using `current_user` anyway. This commit fixes that issue, and renames the method to something that is obviously in use for rapidfire, as opposed to the general `scoped` name.