### PR TITLE
lock dev-dependency rspec-rails to '~> 3.6.1'

### DIFF
--- a/rapidfire.gemspec
+++ b/rapidfire.gemspec
@@ -24,7 +24,7 @@ PIM
   s.add_dependency 'active_model_serializers', '~> 0.8.1'
 
   s.add_development_dependency 'sqlite3'
-  s.add_development_dependency 'rspec-rails'
+  s.add_development_dependency 'rspec-rails', '~> 3.6.1'
   s.add_development_dependency 'shoulda'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_girl_rails'


### PR DESCRIPTION
Resolves [puma not being loaded ](https://github.com/rspec/rspec-rails/issues/1882) for Rails 5.1+ 