### PR TITLE
Fix sqlite related travis issue & remove unsupported ruby-rails versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
 language: ruby
 
 rvm:
-  - 2.1.10
-  - 2.2.10
-  - 2.3.8
   - 2.4.5
   - 2.5.3
+  - 2.6.3
 
 gemfile:
-  - gemfiles/Gemfile.rails-3.2.x
-  - gemfiles/Gemfile.rails-4.0.x
-  - gemfiles/Gemfile.rails-4.1.x
   - gemfiles/Gemfile.rails-4.2.x
   - gemfiles/Gemfile.rails-5.0.x
   - gemfiles/Gemfile.rails-5.1.x
@@ -18,37 +13,11 @@ gemfile:
 
 matrix:
   exclude:
-    # has test/unit/testcase removed, and also 3.2.x is too old to support
-    # ruby 2.2.x. so ignoring this combination.
-    - rvm: 2.2.10
-      gemfile: gemfiles/Gemfile.rails-3.2.x
-    # rack with rails 5 cannot be installed in ruby versions prior to 2.2.2
-    - rvm: 2.1.10
-      gemfile: gemfiles/Gemfile.rails-5.0.x
-    # Numeric incompatabilty with Rails 5.1.x
-    - rvm: 2.1.10
-      gemfile: gemfiles/Gemfile.rails-5.1.x
-    # Rails 5.2.x doesn't support ruby 2.1.x
-    - rvm: 2.1.10
-      gemfile: gemfiles/Gemfile.rails-5.2.x
-    # Numeric incompatabilty with Rails 3.2.x
-    - rvm: 2.4.5
-      gemfile: gemfiles/Gemfile.rails-3.2.x
-    # Numeric incompatabilty with Rails 4.0.x
-    - rvm: 2.4.5
-      gemfile: gemfiles/Gemfile.rails-4.0.x
-    # Numeric incompatabilty with Rails 4.1.x
-    - rvm: 2.4.5
-      gemfile: gemfiles/Gemfile.rails-4.1.x
-    # Integer is incompatabilty with Rails 3.2.x
+    # Travis by default installs bundler 2.1, rails 4.2 requires < 2.0
     - rvm: 2.5.3
-      gemfile: gemfiles/Gemfile.rails-3.2.x
-    # Numeric incompatabilty with Rails 4.0.x
-    - rvm: 2.5.3
-      gemfile: gemfiles/Gemfile.rails-4.0.x
-    # Numeric incompatabilty with Rails 4.1.x
-    - rvm: 2.5.3
-      gemfile: gemfiles/Gemfile.rails-4.1.x
+      gemfile: gemfiles/Gemfile.rails-4.2.x
+    - rvm: 2.6.3
+      gemfile: gemfiles/Gemfile.rails-4.2.x
 
 before_script:
   - RAILS_ENV=test bundle exec rake db:migrate --trace

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 One stop solution for all survey related requirements! Its tad easy!
 
-This gem supports **rails 3.2.13+**, **rails4** and **rails5** versions.
+This gem supports **rails 4.2.0+** and **rails5** with **ruby 2.4** and later.
 
 You can see a demo of this gem [here](https://rapidfire.herokuapp.com).
 And the source code of demo [here](https://github.com/code-mancers/rapidfire-demo).

--- a/app/controllers/rapidfire/attempts_controller.rb
+++ b/app/controllers/rapidfire/attempts_controller.rb
@@ -1,6 +1,6 @@
 module Rapidfire
   class AttemptsController < Rapidfire::ApplicationController
-    if Rails::VERSION::MAJOR ==  5
+    if Rails::VERSION::MAJOR == 5
       before_action :find_survey!
     else
       before_filter :find_survey!

--- a/db/migrate/20170701191411_add_after_survey_content_to_survey.rb
+++ b/db/migrate/20170701191411_add_after_survey_content_to_survey.rb
@@ -1,4 +1,11 @@
-class AddAfterSurveyContentToSurvey < ActiveRecord::Migration[5.0]
+if Rails::VERSION::MAJOR == 5
+  version = [Rails::VERSION::MAJOR, Rails::VERSION::MINOR].join('.').to_f
+  base = ActiveRecord::Migration[version]
+else
+  base = ActiveRecord::Migration
+end
+
+class AddAfterSurveyContentToSurvey < base
   def change
     add_column :rapidfire_surveys, :after_survey_content, :text
   end

--- a/gemfiles/Gemfile.rails-3.2.x
+++ b/gemfiles/Gemfile.rails-3.2.x
@@ -1,7 +1,0 @@
-# -*- ruby -*-
-
-source 'https://rubygems.org'
-
-gemspec path: '..'
-gem 'rails', '~> 3.2.13'
-gem 'test-unit', '~> 3.0'

--- a/gemfiles/Gemfile.rails-4.0.x
+++ b/gemfiles/Gemfile.rails-4.0.x
@@ -1,6 +1,0 @@
-# -*- ruby -*-
-
-source 'https://rubygems.org'
-
-gemspec path: '..'
-gem 'rails', '~> 4.0.0'

--- a/gemfiles/Gemfile.rails-4.1.x
+++ b/gemfiles/Gemfile.rails-4.1.x
@@ -1,6 +1,0 @@
-# -*- ruby -*-
-
-source 'https://rubygems.org'
-
-gemspec path: '..'
-gem 'rails', '~> 4.1.0'

--- a/gemfiles/Gemfile.rails-4.2.x
+++ b/gemfiles/Gemfile.rails-4.2.x
@@ -4,3 +4,4 @@ source 'https://rubygems.org'
 
 gemspec path: '..'
 gem 'rails', '~> 4.2.0'
+gem 'sqlite3', '~> 1.3.6'

--- a/gemfiles/Gemfile.rails-5.0.x
+++ b/gemfiles/Gemfile.rails-5.0.x
@@ -4,3 +4,4 @@ source 'https://rubygems.org'
 
 gemspec path: '..'
 gem 'rails', '~> 5.0.0'
+gem 'sqlite3', '~> 1.3.6'

--- a/gemfiles/Gemfile.rails-5.1.x
+++ b/gemfiles/Gemfile.rails-5.1.x
@@ -4,3 +4,4 @@ source 'https://rubygems.org'
 
 gemspec path: '..'
 gem 'rails', '~> 5.1.0'
+gem 'sqlite3', '~> 1.3.6'


### PR DESCRIPTION
For rails versions less than 5.2, ActiveRecord needs the sqlite3 version
1.3.6 internally but the version installed with bundle is 1.4.1 due to
which migration fails in specs. So hardcode sqlite3 versions to 1.3.6 in
rails < 5.2 with this PR. You can find more details about the issue
[here](https://stackoverflow.com/questions/54527277/cant-activate-sqlite3-1-3-6-already-activated-sqlite3-1-4-0)

Also, ruby versions less than 2.4 and rails versions less than 4.2. are
no more officially supported, so remove those versions from travis matrix
as we don't need to support those versions anymore.

There is one more fix where the `AddAfterSurveyContentToSurvey`
migration's base class was hardcoded to have [5] at the end, keeping it
dynamic will fix issues as that is not supported in prior versions