### PR TITLE
fix(checkbox-answers):match answer_text to ActionController::Parameters

### DIFF
--- a/app/models/rapidfire/attempt.rb
+++ b/app/models/rapidfire/attempt.rb
@@ -1,7 +1,12 @@
 module Rapidfire
   class Attempt < ActiveRecord::Base
     belongs_to :survey
-    belongs_to :user, polymorphic: true
     has_many   :answers, inverse_of: :attempt, autosave: true
+
+    if Rails::VERSION::MAJOR >= 5
+      belongs_to :user, polymorphic: true, optional: true
+    else
+      belongs_to :user, polymorphic: true
+    end
   end
 end

--- a/app/services/rapidfire/attempt_builder.rb
+++ b/app/services/rapidfire/attempt_builder.rb
@@ -13,22 +13,21 @@ module Rapidfire
 
     def save!(options = {})
       params.each do |question_id, answer_attributes|
-        if answer = @attempt.answers.find { |a| a.question_id.to_s == question_id.to_s }
-          text = answer_attributes[:answer_text]
+        answer = @attempt.answers.find { |a| a.question_id.to_s == question_id.to_s }
+        next unless answer
 
-          # in case of checkboxes, values are submitted as an array of
-          # strings. we will store answers as one big string separated
-          # by delimiter.
-          text = text.values if text.is_a?(Hash)
-          answer.answer_text =
-            if text.is_a?(Array)
-              strip_checkbox_answers(text).join(Rapidfire.answers_delimiter)
-            elsif text.is_a?(ActionController::Parameters)
-              text.values.join(Rapidfire.answers_delimiter)
-            else
-              text
-            end
-        end
+        text = answer_attributes[:answer_text]
+
+        # in case of checkboxes, values are submitted as an array of
+        # strings. we will store answers as one big string separated
+        # by delimiter.
+        text = text.values if text.is_a?(ActionController::Parameters)
+        answer.answer_text =
+          if text.is_a?(Array)
+            strip_checkbox_answers(text).join(Rapidfire.answers_delimiter)
+          else
+            text
+          end
       end
 
       @attempt.save!(options)

--- a/app/views/rapidfire/answers/_checkbox.html.erb
+++ b/app/views/rapidfire/answers/_checkbox.html.erb
@@ -5,7 +5,7 @@
 <%= f.fields_for :answer_text do |af| %>
   <%- answer.question.options.each_with_index do |option, index| %>
     <%= af.label index do %>
-      <%= check_box_tag "attempt[#{answer.question.id}][answer_text][#{index}]", option, checkbox_checked?(answer, option) %>
+      <%= af.check_box index, { checked: checkbox_checked?(answer, option) }, option %>
       <%= option %>
     <% end %>
   <% end %>


### PR DESCRIPTION
From rails 4, the parameters are not just pure hashes, they are
represented with ActionController::Parameters type(strong params).
In the attempts controller we are still comparing the answer_text with
Hash, so change that to ActionController::Parameters with this.

Since the minimum supported rails version is 4.2, we don't need to
test for pure `Hash` as it will always be `ActionController::Parameters`
in the versions later than 4.

Also, In rails 5, `belongs_to` adds the required validation by default with
it. Make it optional so that non-logged in users can also take the
survey.

Fixes #114 
Also Fixes #145 